### PR TITLE
Fix compilation error due to type mismatch

### DIFF
--- a/torcs_ros_drive_ctrl/src/torcs_ros_drive_ctrl_node.cpp
+++ b/torcs_ros_drive_ctrl/src/torcs_ros_drive_ctrl_node.cpp
@@ -405,7 +405,7 @@ void TORCSROSDriveCtrl::getParams()
   if(!pnh_.hasParam("wheelRadius"))
   {
     ROS_WARN("No parameter wheelRadius on parameter server. Using default value [{0.3306,0.3306,0.3276,0.3276}].");
-    int mydoubles[] = {0.3306,0.3306,0.3276,0.3276};
+    double mydoubles[] = {0.3306, 0.3306, 0.3276, 0.3276};
     std::vector<double> wheelRadius_default(mydoubles, mydoubles + sizeof(mydoubles) / sizeof(double) );
     pnh_.setParam("wheelRadius", wheelRadius_default);
     config_.wheelRadius = wheelRadius_default;


### PR DESCRIPTION
Perhaps a typo? 

with type int catkin_make fails on my machine with: `narrowing conversion of ‘3.306e-1’ from ‘double’ to ‘int’ inside { } [-Wnarrowing]` ; changing the type to double fixes that error.